### PR TITLE
added check for tantalus when decompressing spec

### DIFF
--- a/datamanagement/add_analysis.py
+++ b/datamanagement/add_analysis.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import os
+import sys
+import click
+import json
+import ast
+import pandas as pd
+
+from utils.constants import LOGGING_FORMAT
+from utils.runtime_args import parse_runtime_args
+from dbclients.tantalus import TantalusApi
+import datamanagement.templates as templates
+
+logging.basicConfig(format=LOGGING_FORMAT, stream=sys.stdout, level=logging.INFO)
+
+REQUIRED_FIELDS = [
+    'name',
+    'jira_id',
+    'type',
+    'version',
+]
+
+
+@click.group()
+def input_type():
+    pass
+
+
+@input_type.command()
+@click.argument('json_file')
+@click.option('--update', is_flag=True)
+def json_input(**kwargs):
+    missing_input = False
+    
+    #Parse the input json file
+    try:
+        with open(kwargs['json_file']) as f:
+            inputs = json.load(f)
+    except:
+        inputs = json.loads(kwargs['json_file'])
+
+    #Check that arguments have the right name
+    for key, val in inputs.iteritems():
+        if key not in REQUIRED_FIELDS:
+            raise Exception("Unrecognized input for {}".format(key))
+
+    #Check if all required arguments are present
+    for key in REQUIRED_FIELDS:
+        if key not in inputs:
+            logging.error("Missing input for {}".format(key))
+            missing_input = True
+    
+    if missing_input:
+        raise Exception("Please add missing inputs")
+
+    inputs["update"] = kwargs['update']
+
+    #Call main with these arguments
+    add_analysis(**inputs)
+
+
+@input_type.command()
+@click.argument('name', nargs=1)
+@click.argument('jira_id', nargs=1)
+@click.argument('type', nargs=1)
+@click.argument('version', nargs=1)
+@click.option('--update', is_flag=True)
+def command_line(**kwargs): 
+    #Call main with these arguments
+    add_analysis(**kwargs)
+
+
+def add_analysis(**kwargs):
+    tantalus_api = TantalusApi()
+
+    #Create new analysis object
+    analysis = tantalus_api.get_or_create(
+            "analysis",
+            name=kwargs['name'],
+            jira_ticket=kwargs['jira_id'],
+            analysis_type=kwargs['type'],
+            version=kwargs['version']
+    )
+
+    logging.info("Successfully created analysis with ID {}".format(analysis["id"]))
+
+
+if __name__ == '__main__':
+    input_type()

--- a/datamanagement/query_gsc_for_wgs_bams.py
+++ b/datamanagement/query_gsc_for_wgs_bams.py
@@ -143,15 +143,13 @@ def add_gsc_wgs_bam_dataset(
         storage["storage_directory"], tantalus_bai_filename
     )
 
-
-
     #If this is a spec file, create a bam file in the tantlus_bam_path destination
     if is_spec:
         transferred = create_bam( 
                             bam_path, 
                             lane_infos[0]['reference_genome'], 
-                            tantalus_bam_path)                         
-
+                            tantalus_bam_path,
+                            storage)                         
     #Otherwise, copy the bam and the bam index to the specified tantalus path
     else:
         if not os.path.isfile(tantalus_bam_path):
@@ -186,8 +184,6 @@ def add_gsc_wgs_bam_dataset(
             
         else:
             logging.info("The bam index already exists at {}. Skipping import".format(tantalus_bai_path))
-            
-    
 
     return tantalus_bam_path, transferred
     
@@ -574,11 +570,10 @@ def main(
                             flowcell_id=lane["flowcell_id"],
                             dna_library=library_pk,
                             read_type=lane["read_type"],
-                            lane_number=lane["lane_number"],
+                            lane_number=str(lane["lane_number"]),
                             sequencing_centre=instance["sequencing_centre"],
                             sequencing_instrument=lane["sequencing_instrument"])
                         logging.info("Successfully created lane {} in tantalus".format(lane["id"]))
-   
 
 
 if __name__ == "__main__":

--- a/datamanagement/spec_to_bam.py
+++ b/datamanagement/spec_to_bam.py
@@ -9,6 +9,7 @@ import socket
 import subprocess
 import sys
 from dbclients.tantalus import TantalusApi
+from dbclients import basicclient
 from utils.runtime_args import parse_runtime_args
 from utils.constants import LOGGING_FORMAT
 
@@ -169,7 +170,7 @@ def create_bam( spec_path,
                 filename=output_bam_filename
         )
         file_size = file_resource["size"]
-    except:
+    except basicclient.NotFoundError as e:
         file_size = None
 
     #Check if the file exists on the to_storage, and if it exists in Tantalus with the same size

--- a/datamanagement/spec_to_bam.py
+++ b/datamanagement/spec_to_bam.py
@@ -8,8 +8,10 @@ import re
 import socket
 import subprocess
 import sys
+from dbclients.tantalus import TantalusApi
 from utils.runtime_args import parse_runtime_args
 from utils.constants import LOGGING_FORMAT
+
 
 # Set up the root logger
 logging.basicConfig(format=LOGGING_FORMAT, stream=sys.stdout, level=logging.INFO)
@@ -156,11 +158,25 @@ def get_filepaths(spec_path, to_storage_prefix):
     
 def create_bam( spec_path, 
                 reference_genome, 
-                output_bam_path):
+                output_bam_path,
+                to_storage):
+    tantalus_api = TantalusApi()         
+    output_bam_filename = output_bam_path[len(to_storage["prefix"]) + 1:] 
 
+    try:
+        file_resource = tantalus_api.get(
+                "file_resource",
+                filename=output_bam_filename
+        )
+        file_size = file_resource["size"]
+    except:
+        file_size = None
+
+    #Check if the file exists on the to_storage, and if it exists in Tantalus with the same size
     if os.path.isfile(output_bam_path):
-        logging.warning("An uncompressed BAM file already exists at {}. Skipping decompression of spec file".format(output_bam_path))
-        return False
+        if os.path.getsize(output_bam_path) == file_size:
+            logging.warning("An uncompressed BAM file already exists at {}. Skipping decompression of spec file".format(output_bam_path))
+            return False
 
     try:
         spec_to_bam(
@@ -188,6 +204,7 @@ def main():
         json = {
             "spec_path": spec_path,
             "reference_genome": reference_genome,
+            "output_bam_path": output_bam_path,
             "to_storage": to_storage
         }
 
@@ -199,7 +216,8 @@ def main():
     created = create_bam(
                 args['spec_path'],
                 args['reference_genome'], 
-                output_bam_path)
+                output_bam_path,
+                to_storage)
 
 
 if __name__ == '__main__':

--- a/dbclients/tantalus.py
+++ b/dbclients/tantalus.py
@@ -116,6 +116,11 @@ class BlobStorageClient(object):
             self.storage_container, 
             blob_name=blobname,
             stream=stream)
+        
+    def create(self, blobname, filepath):
+        self.blob_service.create_blob_from_path(self.storage_container, 
+            blobname,
+            filepath)
 
 
 class ServerStorageClient(object):


### PR DESCRIPTION
Added a check to see whether the spec to bam conversion had previously failed. 
Checks whether the file exists on the destination server. If it does, the code checks whether the decompressed bam is on Tantalus and has the same size as the bam on the destination server. Else it decompresses the file again. 